### PR TITLE
Swift: make tenantName optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = (config) => {
   const _auth = Array.isArray(config) && config.length > 0 ? config[0] : config;
   if (_auth?.accessKeyId && _auth?.secretAccessKey && _auth?.url && _auth?.region) {
     return s3(config);
-  } else if (_auth?.username && _auth?.password && _auth?.authUrl && _auth?.tenantName && _auth?.region) {
+  } else if (_auth?.username && _auth?.password && _auth?.authUrl && _auth?.region) {
     return swift(config);
   } else {
     throw new Error("Storage connexion not recognised - did you provide correct credentials for a S3 or Swift storage?")

--- a/swift.js
+++ b/swift.js
@@ -52,14 +52,14 @@ module.exports = (config) => {
             }
           }
         },
-        scope : {
+        ...(_storage.tenantName ? {scope : {
           project : {
             domain : {
               id : 'default'
             },
             name : _storage.tenantName
           }
-        }
+        }} : {})
       }
     };
 


### PR DESCRIPTION
Some (all?) Swift storage services do not require a tenantName. Therefore, make this parameter optional.

Tested with OVHcloud Swift and it works fine.