### PR TITLE
Swift: filter requested endpoints by interface

### DIFF
--- a/swift.js
+++ b/swift.js
@@ -27,8 +27,8 @@ module.exports = (config) => {
    *
    * @param {function} callback function(err):void = The `err` is null by default.
    */
-  function connection (callback, originStorage = 0) {
-    const arrayArguments = [callback, originStorage];
+  function connection (callback, originStorage = 0, options) {
+    const arrayArguments = [callback, originStorage, options];
 
     if (_config.activeStorage === _config.storages.length) {
       /**  Reset the index of the actual storage */
@@ -98,7 +98,11 @@ module.exports = (config) => {
       }
 
       _config.endpoints = _serviceCatalog.endpoints.find((element) => {
-        return element.region?.toLowerCase() === _storage.region?.toLowerCase();
+        const isSameRegion = element.region?.toLowerCase() === _storage.region?.toLowerCase();
+
+        return options && options.interface
+          ? element.interface?.toLowerCase() === options.interface.toLowerCase() && isSameRegion
+          : isSameRegion;
       });
 
       if (!_config.endpoints) {


### PR DESCRIPTION
Sometimes on connection, Swift server returns endpoints in the wrong order, so the client may use the `admin` endpoint instead of the `public` one, for instance.
```js
     // Will take the first endpoint with no other checks
      _config.endpoints = _serviceCatalog.endpoints.find((element) => {
        return element.region?.toLowerCase() === _storage.region?.toLowerCase();
      });
```
That leads to `forbidden` errors in some cases.

The suggestion is to add an option to filter endpoints by their interface